### PR TITLE
Move tagline a bit higher that the install button is more in the viewport

### DIFF
--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -27,7 +27,7 @@ export default function index() {
         <div className="w-[93.194%] mx-auto ">
           <Navigation />
           <div className="xl:mt-20 mt-22 lg:mt-0 flex flex-col lg:flex-row items-center lg:items-[inherit] justify-between font-secondary">
-            <div className="xl:max-w-[39rem] lg:w-1/2 text-albyColdGray-800 text-center lg:text-left lg:pt-40">
+            <div className="xl:max-w-[39rem] lg:w-1/2 text-albyColdGray-800 text-center lg:text-left">
               <h1 className="mb-4 lg:mb-0 xl:text-[4rem] xl:leading-[110%] text-black md:text-4xl text-3xl font-black">
                 Lightning buzz for your Browser
               </h1>


### PR DESCRIPTION
<img width="500" alt="image" src="https://user-images.githubusercontent.com/318/152676560-ad165a50-c3ff-4cfb-88f3-08e181c57d16.png">

vs.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/318/152676568-b69b028e-cafa-4c39-b86d-feea74be954b.png">
