### PR TITLE
Add more margin for mobile

### DIFF
--- a/app/components/Navigation.jsx
+++ b/app/components/Navigation.jsx
@@ -4,7 +4,7 @@ import InstallExtensionButtonPlain from "./InstallExtensionButtonPlain";
 function Navigation() {
   return (
     <div className="flex justify-center">
-      <div className="block md:flex top-0 pt-5 pb-8 lg:pb-0 items-center static md:absolute w-[93.194%] justify-center lg:justify-between max-h-[6.25rem]">
+      <div className="block md:flex top-0 pt-5 pb-8 lg:pb-0 items-center static md:absolute w-[93.194%] justify-center lg:justify-between">
         <div>
           <a href="/">
             <img

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -27,7 +27,7 @@ export default function index() {
       <div className=" bg-albyYellow-300 min-h-screen grid place-items-center relative">
         <div className="w-[93.194%] mx-auto ">
           <Navigation />
-          <div className="xl:mt-20 mt-42 lg:mt-0 flex flex-col lg:flex-row items-center lg:items-[inherit] justify-between font-secondary 2xl:justify-center 2xl:gap-20">
+          <div className="xl:mt-20 mt-56 md:mt-42 lg:mt-0 flex flex-col lg:flex-row items-center lg:items-[inherit] justify-between font-secondary 2xl:justify-center 2xl:gap-20">
             <div className="xl:max-w-[39rem] lg:w-1/2 text-albyColdGray-800 text-center lg:text-left">
               <h1 className="mb-4 lg:mb-0 xl:text-[4rem] xl:leading-[110%] text-black md:text-4xl text-3xl font-black">
                 Lightning buzz for your Browser

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -27,7 +27,7 @@ export default function index() {
       <div className=" bg-albyYellow-300 min-h-screen grid place-items-center relative">
         <div className="w-[93.194%] mx-auto ">
           <Navigation />
-          <div className="xl:mt-20 mt-56 md:mt-42 lg:mt-0 flex flex-col lg:flex-row items-center lg:items-[inherit] justify-between font-secondary 2xl:justify-center 2xl:gap-20">
+          <div className="xl:mt-20 md:mt-42 lg:mt-0 flex flex-col lg:flex-row items-center lg:items-[inherit] justify-between font-secondary 2xl:justify-center 2xl:gap-20">
             <div className="xl:max-w-[39rem] lg:w-1/2 text-albyColdGray-800 text-center lg:text-left">
               <h1 className="mb-4 lg:mb-0 xl:text-[4rem] xl:leading-[110%] text-black md:text-4xl text-3xl font-black">
                 Lightning buzz for your Browser


### PR DESCRIPTION
I added some more margin to the body of the landing page so that the navbar does not overrun it as @moritzka reported in issue #82. I noticed that the navbar is `absolute` positioned which doesn't really make sense because it will naturally be at the top of the page due to being the first element in the DOM. We might want to consider refactoring this in the future, then we don't have to worry about adding margin because the navbar will not spill onto lower elements if it has normal static positioning. I think it also would be good to do a full responsive review of the website at some point.

![image](https://user-images.githubusercontent.com/85003930/156274771-e6e4f574-e6b1-467a-80f6-b7198370d847.png)
