### PR TITLE
Add full URL to meta tag images

### DIFF
--- a/app/root.jsx
+++ b/app/root.jsx
@@ -26,20 +26,20 @@ export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta charSet="utf-8"/>
+        <meta name="viewport" content="width=device-width,initial-scale=1"/>
         <meta name="title" content="Alby — Lightning buzz for your Browser!"/>
         <meta name="description" content="Alby brings Bitcoin to the web with in-browser payments and identity."/>
         <meta property="og:type" content="website"/>
         <meta property="og:url" content="https://getalby.com/"/>
         <meta property="og:title" content="Alby — Lightning buzz for your Browser!"/>
         <meta property="og:description" content="Alby brings Bitcoin to the web with in-browser payments and identity."/>
-        <meta property="og:image" content={AlbyHeadIcon}/>
+        <meta property="og:image" content={`https://getalby.com${AlbyHeadIcon}`}/>
         <meta property="twitter:card" content="summary_large_image"/>
         <meta property="twitter:url" content="https://getalby.com/"/>
         <meta property="twitter:title" content="Alby — Lightning buzz for your Browser!"/>
         <meta property="twitter:description" content="Alby brings Bitcoin to the web with in-browser payments and identity."/>
-        <meta property="twitter:image" content={AlbyHeadIcon}/>
+        <meta property="twitter:image" content={`https://getalby.com${AlbyHeadIcon}`}/>
 
         <script defer data-domain="getalby.com" src="https://squirrel.getalby.com/js/plausible.js"></script>
 


### PR DESCRIPTION
See here for more info: https://github.com/getAlby/website/pull/93#discussion_r823548465

I added the full URL now and to the React path import, see below, let's see if this works:

```<meta property="og:image" content={`https://getalby.com${AlbyHeadIcon}`}/>```

@bumi 