### PR TITLE
Fix padding on footer for v4v page

### DIFF
--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -8,7 +8,7 @@ import InstallExtensionButton from "../components/InstallExtensionButton";
 function Footer() {
   return (
     <>
-      <div className="bg-albyYellow-300 pb-14 lg:pb-32 px-4 md:px-10">
+      <div className="bg-albyYellow-300 py-32 px-4 md:px-10">
         <h3 className="w-11/12 text-center md:w-full font-primary font-bold text-4xl mx-auto">
           Do you have feedback or need help?
         </h3>

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -261,7 +261,7 @@ export default function index() {
         </div>
       )}
 
-      <div className="bg-albyYellow-300 relative py-32">
+      <div className="bg-albyYellow-300 relative pt-32">
         <h2 className="text-4xl font-extrabold text-center mb-4">
           Stay up to date
         </h2>


### PR DESCRIPTION
I noticed the footer padding on the Value4Value page was not right so I fixed it.

Before:
![image](https://user-images.githubusercontent.com/85003930/159362904-b70ec15f-32cb-4e18-af84-1163b3cb6d28.png)

After:
![image](https://user-images.githubusercontent.com/85003930/159362977-4a72b497-e025-4da6-a3b8-e201238b6634.png)
