### PR TITLE
Move do-it footer icon over to match top

### DIFF
--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -39,7 +39,7 @@ function Footer() {
                 The Bitcoin Lightning App for your Browser
               </h3>
               <InstallExtensionButton style="main" />
-              <img src={DoItHint} alt="" className="block my-2 ml-7" />
+              <img src={DoItHint} alt="" className="block my-2 ml-20" />
             </div>
             <div className="flex lg:hidden space-x-10">
               <div className="space-y-2">


### PR DESCRIPTION
Small change but the do-it icon in the footer was much farther to the left than the hero one, so I moved it over to match better.

![image](https://user-images.githubusercontent.com/85003930/159365992-52e22b2f-63da-4391-916d-d6041c8ad6c1.png)

Before:
![image](https://user-images.githubusercontent.com/85003930/159366030-3b5c428c-30ae-46d5-8078-24bce4182675.png)

After:
![image](https://user-images.githubusercontent.com/85003930/159366059-16d27961-e888-40d7-981c-4c26adb4d318.png)
