### PR TITLE
Add feedback board link

### DIFF
--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -22,8 +22,12 @@ function Footer() {
               className="underline"
             >
               Github issue
+            </a>
+            , use the{" "}
+            <a href="https://feedback.getalby.com/" className="underline">
+              Feedback board
             </a>{" "}
-            or join the{" "}
+            for feature requests or join the{" "}
             <a href="https://t.me/getAlby" className="underline">
               Telegram channel
             </a>


### PR DESCRIPTION
Amy and @MoritzKa suggested in Slack that we add the feedback board link to the 'Do you have feedback or need help?' section of the website.