### PR TITLE
style: align alby header and hero on smaller screens

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -17,7 +17,7 @@ function Header() {
               <img
                 src={Logo}
                 alt="Alby"
-                className="mx-auto w-auto lg:h-[3.75rem] h-[2.75rem]"
+                className="mt-4 md:mt-0 mx-auto w-auto lg:h-[3.75rem] h-[2.75rem]"
               />
             </a>
           </div>
@@ -26,7 +26,7 @@ function Header() {
               {installExtension.loading ? null : installExtension.link ? (
                 <a
                   href={installExtension.link || installExtension.defaultLink}
-                  className="mx-auto bg-[#272828] text-white font-secondary inline-block text-lg lg:leading-[1.875rem] font-semibold py-3 px-7 rounded-full mt-6"
+                  className="mx-auto bg-[#272828] text-white font-secondary inline-block text-lg lg:leading-[1.875rem] font-semibold py-3 px-7 rounded-full lg:mt-0 mt-4"
                 >
                   {installExtension.browser && (
                     <img
@@ -44,7 +44,7 @@ function Header() {
                       `We currently do not yet support ${installExtension.browser}. But maybe you can install it from source.`
                     );
                   }}
-                  className="bg-[#272828] text-white font-secondary inline-block text-lg lg:leading-[1.875rem] font-semibold py-3 px-7 rounded-full mt-6"
+                  className="bg-[#272828] text-white font-secondary inline-block text-lg lg:leading-[1.875rem] font-semibold py-3 px-7 rounded-full lg:mt-0 mt-4"
                 >
                   Available for Firefox, Chrome, Opera and others
                 </a>

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -62,11 +62,11 @@ export default function index() {
     <>
       <div
         id="top"
-        className="md:px-20 px-0 bg-albyYellow-300 min-h-screen grid place-items-center relative"
+        className="bg-albyYellow-300 min-h-screen grid place-items-center relative"
       >
         <div className="w-full mx-auto ">
           <Navigation />
-          <div className="flex flex-col lg:flex-row items-center lg:items-[inherit] justify-between font-secondary 2xl:justify-center 2xl:gap-20">
+          <div className="md:px-20 px-0 flex flex-col lg:flex-row items-center lg:items-[inherit] justify-between font-secondary 2xl:justify-center 2xl:gap-20">
             <div className="px-6 md:px-0 xl:max-w-[39rem] lg:w-1/2 text-albyColdGray-800 text-center lg:text-left">
               <h1 className="mb-4 lg:mb-0 xl:leading-[110%] text-black text-4xl md:text-5xl lg:text-6xl font-black">
                 The Bitcoin Lightning App for your Browser


### PR DESCRIPTION
Requested in issue #130 I have aligned the Alby logo in the header to the hero text. I updated this for the screen size shown in the screenshot but left it the way it was for large screens, we had feedback a while ago saying that the hero sections were too far apart and close to the edges on large screens. Also made some minor changes to the responsiveness of the header on the V4V page.

Screenshot:

![image](https://user-images.githubusercontent.com/85003930/168948662-f2a3e4d2-8b5a-4dc8-bde6-446aa447df71.png)
