### PR TITLE
add new subscribe form widget to the footer for the ghost newsletter

### DIFF
--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -152,15 +152,15 @@ function Footer() {
               {!success ? (
                 <form
                   data-members-form="subscribe"
-                  class="w-80"
+                  className="w-80"
                   onSubmit={() => setSuccess(true)}
                 >
-                  <div class="flex mt-2">
+                  <div className="flex mt-2">
                     <input
                       data-members-email
                       type="email"
                       required="true"
-                      class="w-[65%] rounded-l-full border border-white bg-white/25 p-3 placeholder:text-black"
+                      className="w-[65%] rounded-l-full border border-white bg-white/25 p-3 placeholder:text-black"
                       placeholder="Email address..."
                       onChange={(e) => {
                         setEmail(e.target.value);
@@ -172,7 +172,7 @@ function Footer() {
                     <button
                       disabled={(email && !consent) || !email}
                       type="submit"
-                      class={`${
+                      className={`${
                         email && !consent ? "opacity-50" : ""
                       } rounded-r-full bg-[#272828] text-white py-3 px-4`}
                     >
@@ -185,11 +185,11 @@ function Footer() {
                         type="checkbox"
                         checked={consent}
                         required="true"
-                        class="mt-4"
+                        className="mt-4"
                         name="consent"
                         onChange={() => setConsent(!consent)}
                       />
-                      <label for="consent" class="ml-2">
+                      <label for="consent" className="ml-2">
                         I want to get notified about upcoming features and
                         announcements.
                       </label>

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -5,6 +5,7 @@ import TwitterLogo from "../../public/images/twitter-logo.svg";
 import GitHubLogo from "../../public/images/GitHub.svg";
 import YouTubeLogo from "../../public/images/youtube-icon.svg";
 import DoItHint from "../../public/images/do-it-hint.png";
+import Bees from "../../public/images/bees.svg";
 import useInstallExtension from "~/hooks/useInstallExtension";
 
 function Footer() {
@@ -14,7 +15,8 @@ function Footer() {
   const [success, setSuccess] = useState(false);
   return (
     <>
-      <div className="bg-albyYellow-300 py-32 px-4 md:px-10">
+      <div className="bg-albyYellow-300 py-32 px-4 md:px-10 relative">
+        <img src={Bees} alt="bees" className="absolute top-0 right-10" />
         <h3 className="w-11/12 text-center md:w-full font-primary font-bold text-4xl mx-auto">
           Do you have feedback or need help?
         </h3>

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import TelegramLogo from "../../public/images/Telegram.svg";
 import TwitterLogo from "../../public/images/twitter-logo.svg";
 import GitHubLogo from "../../public/images/GitHub.svg";
@@ -7,7 +9,9 @@ import useInstallExtension from "~/hooks/useInstallExtension";
 
 function Footer() {
   const installExtension = useInstallExtension();
-
+  const [email, setEmail] = useState("");
+  const [consent, setConsent] = useState(false);
+  const [success, setSuccess] = useState(false);
   return (
     <>
       <div className="bg-albyYellow-300 py-32 px-4 md:px-10">
@@ -112,7 +116,7 @@ function Footer() {
 
             <div>
               <p className="mt-10 lg:mt-0 text-xl font-bold">Stay in touch</p>
-              <div className="flex lg:justify-center items-center gap-2">
+              <div className="flex items-center gap-2">
                 <a
                   href="https://twitter.com/getalby"
                   target="_blank"
@@ -142,6 +146,59 @@ function Footer() {
                   <img src={YouTubeLogo} alt="YouTube" className="w-10 h-10" />
                 </a>
               </div>
+              <p className="mt-5 text-xl font-bold">
+                {!success ? "Subscribe to newsletter" : `You're signed up!`}
+              </p>
+              {!success ? (
+                <form
+                  data-members-form="subscribe"
+                  class="w-80"
+                  onSubmit={() => setSuccess(true)}
+                >
+                  <div class="flex mt-2">
+                    <input
+                      data-members-email
+                      type="email"
+                      required="true"
+                      class="w-[65%] rounded-l-full border border-white bg-white/25 p-3 placeholder:text-black"
+                      placeholder="Email address..."
+                      onChange={(e) => {
+                        setEmail(e.target.value);
+                        if (email.length === 0) {
+                          setConsent(false);
+                        }
+                      }}
+                    />
+                    <button
+                      disabled={(email && !consent) || !email}
+                      type="submit"
+                      class={`${
+                        email && !consent ? "opacity-50" : ""
+                      } rounded-r-full bg-[#272828] text-white py-3 px-4`}
+                    >
+                      Sign up
+                    </button>
+                  </div>
+                  {email && (
+                    <div>
+                      <input
+                        type="checkbox"
+                        checked={consent}
+                        required="true"
+                        class="mt-4"
+                        name="consent"
+                        onChange={() => setConsent(!consent)}
+                      />
+                      <label for="consent" class="ml-2">
+                        I want to get notified about upcoming features and
+                        announcements.
+                      </label>
+                    </div>
+                  )}
+                </form>
+              ) : (
+                <p>Check your inbox for a confirmation email.</p>
+              )}
             </div>
           </div>
         </div>

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -147,7 +147,7 @@ function Footer() {
                 </a>
               </div>
               <p className="mt-5 text-xl font-bold">
-                {!success ? "Subscribe to newsletter" : `You're signed up!`}
+                {!success ? "Subscribe to newsletter" : "You're signed up!"}
               </p>
               {!success ? (
                 <form
@@ -189,7 +189,7 @@ function Footer() {
                         name="consent"
                         onChange={() => setConsent(!consent)}
                       />
-                      <label for="consent" className="ml-2">
+                      <label htmlFor="consent" className="ml-2">
                         I want to get notified about upcoming features and
                         announcements.
                       </label>

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -42,6 +42,7 @@ export default function App() {
         <meta property="twitter:description" content="Alby brings Bitcoin to the web with in-browser payments and identity."/>
         <meta property="twitter:image" content={`https://getalby.com${OGImage}`}/>
 
+        <script defer src="https://unpkg.com/@tryghost/portal@~2.2.0/umd/portal.min.js" data-ghost="https://blog.getalby.com/" data-key="607246d96432a05b400006a475" data-api="https://alby.ghost.io/ghost/api/content/" crossorigin="anonymous"></script>
         <script defer data-domain="getalby.com" src="https://squirrel.getalby.com/js/plausible.js"></script>
 
         <Meta />

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -42,7 +42,7 @@ export default function App() {
         <meta property="twitter:description" content="Alby brings Bitcoin to the web with in-browser payments and identity."/>
         <meta property="twitter:image" content={`https://getalby.com${OGImage}`}/>
 
-        <script defer src="https://unpkg.com/@tryghost/portal@~2.2.0/umd/portal.min.js" data-ghost="https://blog.getalby.com/" data-key="607246d96432a05b400006a475" data-api="https://alby.ghost.io/ghost/api/content/" crossorigin="anonymous"></script>
+        <script defer src="https://unpkg.com/@tryghost/portal@~2.2.0/umd/portal.min.js" data-ghost="https://blog.getalby.com/" data-key="607246d96432a05b400006a475" data-api="https://alby.ghost.io/ghost/api/content/" crossOrigin="anonymous"></script>
         <script defer data-domain="getalby.com" src="https://squirrel.getalby.com/js/plausible.js"></script>
 
         <Meta />

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -9,7 +9,6 @@ import Landing4 from "../../public/images/landing4.webp";
 import ChevronRight from "../../public/images/chevron-right.svg";
 import Bee1 from "../../public/images/bee1.svg";
 import Bee2 from "../../public/images/bee2.svg";
-import Bees from "../../public/images/bees.svg";
 import Arrows from "../../public/images/arrows.svg";
 import Bolt from "../../public/images/bolt.svg";
 import Shield from "../../public/images/shield.svg";
@@ -302,24 +301,6 @@ export default function index() {
           </div>
         </div>
       )}
-
-      <div className="bg-albyYellow-300 relative pt-32">
-        <h2 className="text-4xl font-extrabold text-center mb-4">
-          Stay up to date
-        </h2>
-        <p className="w-2/3 lg::w-1/3 mx-auto text-center text-xl text-albyColdGray-600">
-          Sign up to get notified about our upcoming features and announcements.
-        </p>
-        <iframe
-          src="https://getalby.substack.com/embed"
-          width="100%"
-          height="320"
-          className=""
-          frameBorder="0"
-          scrolling="no"
-        ></iframe>
-        <img src={Bees} alt="" className="absolute md:bottom-5 right-10" />
-      </div>
 
       <Footer />
     </>


### PR DESCRIPTION
Related issue #137 

I have taken the designs and implemented a new Ghost newsletter signup widget in the footer of the website. I made a couple small changes to the design because I was having a bit of a hard time matching it while keeping the UX clean.

**QUESTION:**

One thing to note is that there are some pages like /demo and /lightning-address that are on our other repo (getalby.com) which is written in Ruby. So this will only update the pages which are using our React app from this Website repo. I am not too familiar with Ruby so I am not sure how easy it would be to port what I wrote in React over to that part of the website. Another option might be to move those pages from the getalby.com to the website repo (unless there is a reason they need to be on the Ruby one). 

If we want this widget to also be in the Blog footer we will have to write re-write this again in JavaScript. So essentially we will have to write it 3 different times in 3 different languages. This isn't ideal for work duplication or a great use of time, but I don't know any way around it unless we bring the blog in-house. Any thoughts on this problem? Maybe we could make an iframe that would be compatible with all frameworks/languages? I've never done that before but I could research it.

Screenshots:

![image](https://user-images.githubusercontent.com/85003930/172695334-12a796b0-074c-4357-90fd-30c1fb0cfbd2.png)

![image](https://user-images.githubusercontent.com/85003930/172695404-579f250e-a445-424a-bd63-a84285be2e05.png)

![image](https://user-images.githubusercontent.com/85003930/172695469-0b9010c1-2473-42e2-a1cb-c272f66c52b8.png)

![image](https://user-images.githubusercontent.com/85003930/172695528-9b422f77-f8d4-4f35-9e48-e47b60e49f88.png)

I also removed the old subscribe section:

![image](https://user-images.githubusercontent.com/85003930/172699641-9567822e-e81c-4354-aba7-81e0ac7314fc.png)